### PR TITLE
move rootless-check to initFirewalld(), log as "info"

### DIFF
--- a/libnetwork/iptables/firewalld.go
+++ b/libnetwork/iptables/firewalld.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/docker/docker/rootless"
 	dbus "github.com/godbus/dbus/v5"
 	"github.com/sirupsen/logrus"
 )
@@ -70,12 +69,6 @@ var (
 // FirewalldInit initializes firewalld management code.
 func FirewalldInit() error {
 	var err error
-
-	// When running with RootlessKit, firewalld is running as the root outside our network namespace
-	// https://github.com/moby/moby/issues/43781
-	if rootless.RunningWithRootlessKit() {
-		return fmt.Errorf("skipping firewalld management for rootless mode")
-	}
 
 	if connection, err = newConnection(); err != nil {
 		return fmt.Errorf("Failed to connect to D-Bus system bus: %v", err)

--- a/libnetwork/iptables/iptables.go
+++ b/libnetwork/iptables/iptables.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/docker/docker/rootless"
 	"github.com/sirupsen/logrus"
 )
 
@@ -105,6 +106,12 @@ func probe() {
 }
 
 func initFirewalld() {
+	// When running with RootlessKit, firewalld is running as the root outside our network namespace
+	// https://github.com/moby/moby/issues/43781
+	if rootless.RunningWithRootlessKit() {
+		logrus.Info("skipping firewalld management for rootless mode")
+		return
+	}
 	if err := FirewalldInit(); err != nil {
 		logrus.Debugf("Fail to initialize firewalld: %v, using raw iptables instead", err)
 	}


### PR DESCRIPTION
As this is an expected scenario, it's better to skip the detection and log, than
to return an error (and ignore / log as debug info).

Perhaps it would be cleaner if we pass the "rootless" mode as an argument to
`GetIptable()` instead (initialise with these options), but there's a lot more
to clean up here.

