### PR TITLE
suggestions for API

### DIFF
--- a/api/server/router/system/system_routes.go
+++ b/api/server/router/system/system_routes.go
@@ -91,6 +91,12 @@ func (s *systemRouter) getInfo(ctx context.Context, w http.ResponseWriter, r *ht
 				info.OperatingSystem = "<unknown>"
 			}
 		}
+		if versions.LessThan(version, "1.44") {
+			for k, rt := range info.Runtimes {
+				// Status field introduced inl API v1.44.
+				info.Runtimes[k] = system.RuntimeWithStatus{Runtime: rt.Runtime}
+			}
+		}
 		if versions.GreaterThanOrEqualTo(version, "1.42") {
 			info.KernelMemory = false
 		}

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -5619,22 +5619,24 @@ definitions:
         description: |
           Information specific to the runtime.
 
-          <p><br /></p>
+          While this API specification does not define data provided by runtimes,
+          the following well-known properties may be provided by runtimes:
+          
+          `org.opencontainers.runtime.features`: features structure as defined
+          in the [OCI Runtime Specification](https://github.com/opencontainers/runtime-spec/blob/main/features.md),
+          in a JSON string representation.
 
+          <p><br /></p>
+          
           > **Note**: The information returned in this field, including the
           > formatting of values and labels, should not be considered stable,
-          > unless explicitly documented here.
-          > Those information may change without notice.
+          > and may change without notice.
         type: "object"
         x-nullable: true
-        properties:
-          features:
-            description: |
-              [features structure](https://github.com/opencontainers/runtime-spec/blob/main/features.md) of
-              the OCI Runtime Spec, in a JSON string representation.
-            type: "string"
         additionalProperties:
           type: "string"
+        example:
+          "org.opencontainers.runtime.features": "{\"ociVersionMin\":\"1.0.0\",\"ociVersionMax\":\"1.1.0\",\"...\":\"...\"}"
 
   Commit:
     description: |


### PR DESCRIPTION
- for https://github.com/moby/moby/pull/46647


Based on some discussions in the maintainers call;

- remove "features" from the API definition, instead documenting it as a "well-known" status field. This keeps the actual definition of the field separate from the API specification, but documenting it as "well-known" property still allows it to be recognisable as a "soft" contract.
- change the "features" field to use a namespaced property ("org.opencontainers.runtime.features") to avoid possible collisions.
- daemon.runtimeStatus(): pass context so that we can use the context-logger
- daemon.runtimeStatus(): use structured logs for runtime-name
- add version-handling code to the `/info` endpoint to omit the new fields on older API versions.

